### PR TITLE
fix: remove PHP parameter declaration deprecations

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -20,7 +20,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <authors>
         <author>
             <name></name>

--- a/Model/LibraryItemImage.php
+++ b/Model/LibraryItemImage.php
@@ -40,7 +40,7 @@ class LibraryItemImage extends BaseLibraryItemImage
     /**
      * {@inheritDoc}
      */
-    public function preInsert(ConnectionInterface $con = null): bool
+    public function preInsert(?ConnectionInterface $con = null): bool
     {
         $this->setPosition($this->getNextPosition());
 
@@ -49,7 +49,7 @@ class LibraryItemImage extends BaseLibraryItemImage
         return true;
     }
 
-    public function preDelete(ConnectionInterface $con = null): bool
+    public function preDelete(?ConnectionInterface $con = null): bool
     {
         parent::preDelete($con);
 

--- a/Service/LibraryItemImageService.php
+++ b/Service/LibraryItemImageService.php
@@ -35,8 +35,8 @@ class LibraryItemImageService
 
     public function createAndAssociateImage(
         File $file,
-        ?string $imageTitle = null,
-        ?string $locale = null,
+        ?string $imageTitle,
+        ?string $locale,
         $itemType,
         $itemId,
         $code = null,


### PR DESCRIPTION
`createAndAssociateImage()` declared two optional parameters before required ones, which PHP 8.3 reports as deprecated and treats as required anyway. The defaults are dropped so the signature matches how every caller already invokes it — no call site changes needed.

The two Propel hooks in `LibraryItemImage` also used an implicitly nullable `ConnectionInterface` parameter, deprecated since PHP 8.4; they now match the generated base class signature.

Version bumped to 2.0.2.