### PR TITLE
fix: return null from getImages when no source has a url

### DIFF
--- a/Plugin/ImaginePlugin.php
+++ b/Plugin/ImaginePlugin.php
@@ -52,7 +52,7 @@ class ImaginePlugin extends AbstractSmartyPlugin
         $template->assign('images', $images);
     }
 
-    public function getImages(array $params): string
+    public function getImages(array $params): ?string
     {
         return $this->imagePluginService->getImages($params);
     }

--- a/Service/ImagePluginService.php
+++ b/Service/ImagePluginService.php
@@ -12,9 +12,25 @@ class ImagePluginService
     {
     }
 
-    public function getImages(array $params): string
+    public function getImages(array $params): ?string
     {
         $imagesData = $this->imageService->getImages($params);
+
+        if ($params['no_placeholder'] ?? false) {
+            $hasUrl = false;
+            foreach ($imagesData as $image) {
+                foreach ($image['sources'] ?? [] as $source) {
+                    if (!empty($source['url'])) {
+                        $hasUrl = true;
+                        break 2;
+                    }
+                }
+            }
+
+            if (!$hasUrl) {
+                return null;
+            }
+        }
 
         $processedImgTag = '';
 

--- a/Twig/TheliaLibraryImage.php
+++ b/Twig/TheliaLibraryImage.php
@@ -31,7 +31,7 @@ class TheliaLibraryImage
     {
     }
 
-    public function getRenderHtmlImages(): string
+    public function getRenderHtmlImages(): ?string
     {
         return $this->imagePluginService->getImages($this->params);
     }


### PR DESCRIPTION
ImagePluginService::getImages() now returns null instead of rendering an empty/placeholder tag when no_placeholder is requested and none of the resolved images expose a url. The two callers (ImaginePlugin's Smarty function and the TheliaLibraryImage Twig component) had their return type widened to ?string to match, since PHP throws a TypeError when a null is returned from a non-nullable string return type.