### PR TITLE
perf: let menus and grids preload the images of their items in one query

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -20,7 +20,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>2.0.4</version>
+    <version>2.0.5</version>
     <authors>
         <author>
             <name></name>

--- a/Service/ImageService.php
+++ b/Service/ImageService.php
@@ -45,6 +45,14 @@ class ImageService
      */
     private array $preloadedImages = [];
 
+    /**
+     * The same rows grouped by the item they belong to, in position order.
+     * See preloadSourceImages().
+     *
+     * @var array<string, array<int, list<object>>>
+     */
+    private array $preloadedBySource = [];
+
     public function __construct(private RequestStack $requestStack, private readonly CacheManager $cacheManager)
     {
     }
@@ -75,6 +83,46 @@ class ImageService
         $this->joinTranslations($query);
 
         foreach ($query->find() as $image) {
+            $this->preloadedImages[$sourceType][(int) $image->getId()] = $image;
+        }
+    }
+
+    /**
+     * Same as preloadImages(), keyed by the owning item rather than the image: for a menu
+     * or a grid of categories that shows the first visual of each, one query for the whole
+     * set instead of one per tile. The getImages() calls that ask by `source_id` — with no
+     * `img_id`, `position` or `offset` — are then answered from these rows, in position order,
+     * with the visibility rule and `limit` applied as the query would.
+     *
+     * @param array<int, int|string> $sourceIds
+     */
+    public function preloadSourceImages(string $sourceType, array $sourceIds): void
+    {
+        $missing = [];
+        foreach (array_unique(array_filter($sourceIds)) as $sourceId) {
+            if (!isset($this->preloadedBySource[$sourceType][(int) $sourceId])) {
+                $missing[] = (int) $sourceId;
+            }
+        }
+
+        if ([] === $missing) {
+            return;
+        }
+
+        // Seed every requested id so an item without image is not queried again.
+        foreach ($missing as $sourceId) {
+            $this->preloadedBySource[$sourceType][$sourceId] = [];
+        }
+
+        $query = $this->createQuery($sourceType);
+        $filterMethod = \sprintf('filterBy%sId', ucfirst($sourceType));
+        $query->$filterMethod($missing, Criteria::IN);
+        $this->joinTranslations($query);
+        $query->orderByPosition();
+
+        $getSourceId = \sprintf('get%sId', ucfirst($sourceType));
+        foreach ($query->find() as $image) {
+            $this->preloadedBySource[$sourceType][(int) $image->$getSourceId()][] = $image;
             $this->preloadedImages[$sourceType][(int) $image->getId()] = $image;
         }
     }
@@ -398,6 +446,21 @@ class ImageService
             }
 
             return [$this->imageData($image, $sourceType)];
+        }
+
+        // The images of one item, with no positional narrowing: preloaded rows answer it too.
+        if (null === $imageId && null !== $sourceId && null === $position && !isset($params['offset'])
+            && isset($this->preloadedBySource[$sourceType][(int) $sourceId])) {
+            $rows = $this->preloadedBySource[$sourceType][(int) $sourceId];
+
+            if (1 === $visible) {
+                $rows = array_values(array_filter($rows, static fn (object $row): bool => (bool) $row->getVisible()));
+            }
+            if (isset($params['limit'])) {
+                $rows = \array_slice($rows, 0, (int) $params['limit']);
+            }
+
+            return array_map(fn (object $row): array => $this->imageData($row, $sourceType), $rows);
         }
 
         /** @var ProductImageQuery $query */


### PR DESCRIPTION
## What

Follow-up to #34. `preloadImages()` batches the rows when the caller already knows which image it will show. A menu or a category grid does not: it asks `getImages()` for the first visual **of each item** (`source_id`), one query per tile — fourteen on every page of a shop with fourteen top-level categories.

## Changes

- New `ImageService::preloadSourceImages(string $sourceType, array $sourceIds)`: one query for the images of all the given items, translations joined, rows kept in position order per item. Items without an image are seeded, so they are not queried again.
- `getImageDataWithType()` answers from those rows when the call asks by `source_id` with no `img_id`, `position` or `offset`, applying the visibility rule and `limit` the way the query did. Every other shape still goes through the query.
- Bump the module to 2.0.5.

## Measured

Header menu with 14 tiles: 14 `category_image` queries per page before, 1 after. Rendered HTML identical.